### PR TITLE
Debugged program

### DIFF
--- a/photoflash/Gemfile
+++ b/photoflash/Gemfile
@@ -48,10 +48,9 @@ group :development do
   gem 'spring'
 end
 
-  #gems for image management
-  gem 'carrierwave'
-  gem 'image_magick'
-  gem 'mini_magick', '~> 3.5.0'
-  gem 'fog'
-  gem 'figaro'
-  gem 'unf'
+#gems for image management
+gem 'carrierwave-aws'
+gem 'mini_magick', '~> 3.5.0'
+gem 'fog'
+gem 'figaro'
+gem 'unf'

--- a/photoflash/Gemfile.lock
+++ b/photoflash/Gemfile.lock
@@ -38,6 +38,12 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
+    aws-sdk (2.5.7)
+      aws-sdk-resources (= 2.5.7)
+    aws-sdk-core (2.5.7)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.5.7)
+      aws-sdk-core (= 2.5.7)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -48,6 +54,9 @@ GEM
       json (>= 1.7)
       mime-types (>= 1.16)
       mimemagic (>= 0.3.0)
+    carrierwave-aws (1.0.1)
+      aws-sdk (~> 2.0)
+      carrierwave (~> 0.7)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -195,12 +204,12 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
-    image_magick (0.1.9)
     inflecto (0.0.2)
     ipaddress (0.8.3)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
+    jmespath (1.3.1)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -320,11 +329,10 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  carrierwave
+  carrierwave-aws
   coffee-rails (~> 4.1.0)
   figaro
   fog
-  image_magick
   jbuilder (~> 2.0)
   jquery-rails
   mini_magick (~> 3.5.0)
@@ -338,6 +346,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unf
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.12.5

--- a/photoflash/app/uploaders/photo_uploader.rb
+++ b/photoflash/app/uploaders/photo_uploader.rb
@@ -15,9 +15,9 @@ class PhotoUploader < CarrierWave::Uploader::Base
 
  # Choose what kind of storage to use for this uploader:
  # storage :file
- #storage = fog
+ storage :fog
 
- Fog::Storage::AWS::DEFAULT_REGION = 'eu-west-1'
+ Fog::Storage::AWS::DEFAULT_REGION = 'us-east-1'
 
  # Override the directory where uploaded files will be stored.
  # This is a sensible default for uploaders that are meant to be mounted:

--- a/photoflash/config/initializers/fog.rb
+++ b/photoflash/config/initializers/fog.rb
@@ -5,6 +5,6 @@ CarrierWave.configure do |config|
     :aws_secret_access_key  => ENV['AWS_SECRET_ACCESS_KEY']
   }
 
-  config.fog_directory  = ENV['AWS_S3_BUCKET']
-  #config.fog_public     = false
+  config.fog_directory  = ENV['AWS_BUCKET']
+  config.fog_public     = false
 end


### PR DESCRIPTION
1. I removed the image_magick gem from the gemfile, it's a dependency and shouldn't be called directly in the gemfile.
2. I swapped out carrierwave for carrierwave-aws, I think this is required when designating a region. I've never had to use it before but it may help for international buckets.
3. I turned on fog in the uploader
4. I swapped out the environment variable name. In the tutorial I use ENV['AWS_BUCKET']  but you had ENV['AWS_S3_BUCKET'] . You can call the variable anything that you want, but it has to exactly match the name in the application.yml file. I ran into a 403 permission error because the name was different than the ENV variables that I copied over.
